### PR TITLE
Optionally enable security for Kafka and OpenNMS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ crash.log
 # version control.
 #
 # example.tfvars
+custom.tfvars
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ All VMs will have the Net-SNMP agent configured and running.
 
 For instance, if `location=eastus` and `username=agalue`, the FQDNs would be:
 
-* `agalue-onms.eastus.cloudapp.opennms.com` (WebUI=8980, Grafana=3000, SSH=22)
+* `agalue-onms.eastus.cloudapp.opennms.com` (with `security.enabled=false` OpenNMS WebUI=8980 and Grafana=3000; with `security.enabled=true`, both available at 443 (use `/grafana` for Grafana)
 * `agalue-kafka.eastus.cloudapp.opennms.com` (Client=9094)
 * `agalue-elastic.eastus.cloudapp.opennms.com` (Kibana=5601)
+
+All instances have SSH access.
 
 ## Start the lab
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a simple test environment running in Azure made with [Terraform](https:/
   - RRDtool for metrics with `storeByGroup` and `storeByForeignSource` enabled
 - A VM with Elasticsearch 7.6.2 and Kibana 7.6.2 for Flow Processing
   - OpenNMS Drift Plugin installed
-- A VM with Zookeeper 3.5, Kafka 2.8.0, and CMAK (started via Docker).
+- A VM with Zookeeper 3.5, Kafka 2.8.1, and CMAK (started via Docker).
 
 All VMs are based on CentOS 8 and will be initialized via [cloud-init](https://cloudinit.readthedocs.io/en/latest/) scripts modified at runtime by Terraform based on the chosen variables.
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,15 @@ export azure_location="eastus"
 export minion_id="minion01"
 export minion_location="Apex"
 export minion_heap="1g"
+export security_enabled="false"
+export kafka_user="opennms"
+export kafka_passwd="0p3nNM5;"
 
 envsubst < minion-template.yaml > /tmp/$minion_id.yaml
 multipass launch -m 2G -n $minion_id --cloud-init /tmp/$minion_id.yaml
 ```
+
+> Make sure to use use the appropriate `security_enabled` based on how you started the lab, and the credentials are correct (check `vars.tf`).
 
 The template assumes you haven't changed the `locals` entry inside `vars.tf`.
 

--- a/README.md
+++ b/README.md
@@ -78,22 +78,20 @@ If you want to install a specific version of OpenNMS, you should provide a value
 For testing purposes, this repository provides a `cloud-init` YAML file for Minion, you can use with [multipass](https://multipass.run/). It contains some templating variables you can replace using [envsubst](https://www.gnu.org/software/gettext/manual/html_node/envsubst-Invocation.html); for instance:
 
 ```bash
-export user="agalue"
-export azure_location="eastus"
-export minion_id="minion01"
+export name_prefix="ag-lab1"    # Must match name_prefix in Terraform
+export azure_location="eastus"  # Must match location in Terraform
+export security_enabled="false" # Must match security.enabled in Terraform
+export kafka_user="opennms"     # Must match security.kafka_user in Terraform
+export kafka_passwd="0p3nNM5;"  # Must match security.kafka_passwd in Terraform
+export minion_heap="512m"       # Must be less than the value specified via -m in multipass
 export minion_location="Apex"
-export minion_heap="512m"
-export security_enabled="false"
-export kafka_user="opennms"
-export kafka_passwd="0p3nNM5;"
+export minion_id="ag-minion01"
 
 envsubst < minion-template.yaml > /tmp/$minion_id.yaml
 multipass launch -m 1G -n $minion_id --cloud-init /tmp/$minion_id.yaml
 ```
 
-> Make sure to use use the appropriate `security_enabled` based on how you started the lab, and the credentials are correct (check `vars.tf`).
-
-The template assumes you haven't changed the `locals` entry inside `vars.tf`.
+> Ensure the usage of the appropriate content based on how you started the lab.
 
 ## Destroy the lab
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ terraform init
 * Create the resources in Azure
 
 ```bash
-terraform apply -var "username=agalue" -var "password=1HateWind0ws;"
+terraform apply \
+  -var "username=agalue" \
+  -var "password=1HateWind0ws;" \
+  -var "email=agalue@opennms.org"
 ```
 
 The above assumes there is already a resource group called `support-testing` created in Azure, on which Terraform will create all the resources.
@@ -53,9 +56,12 @@ If you want to create the resource group, you can run the following instead:
 terraform apply \
   -var "username=agalue" \
   -var "password=1HateWind0ws;" \
+  -var "email=agalue@opennms.org" \
   -var "resource_group_create=true" \
   -var "resource_group_name=OpenNMS"
 ```
+
+Additionally, if you want to enable SCRAM authentication for Kafka and TLS Encrytion via LetsEncrypt for OpenNMS and Kafka, add `-var "security.enabled=true"` to the list of variables.
 
 All the resources will be prefixed by the content of the `username` variable for their names.
 

--- a/README.md
+++ b/README.md
@@ -53,19 +53,34 @@ terraform apply \
 
 The above assumes there is already a resource group called `support-testing` created in Azure, on which Terraform will create all the resources.
 
-If you want to create the resource group, you can run the following instead:
+If you want to create the resource group, enable security and change other settings, we recommend to use a `.tfvars` file, for instance:
 
 ```bash
-terraform apply \
-  -var "name_prefix=ag-lab1" \
-  -var "username=agalue" \
-  -var "password=1HateWind0ws;" \
-  -var "email=agalue@opennms.org" \
-  -var "resource_group.create=true" \
-  -var "resource_group.name=OpenNMS"
+cat <<EOF > custom.tfvars
+name_prefix = "ag-lab1"
+username = "agalue"
+password = "1HateWind0ws;"
+email = "agalue@opennms.org"
+resource_group = {
+  create = true
+  name   = "OpenNMS"
+}
+security = {
+  enabled      = true
+  zk_user      = "zkonms"
+  zk_passwd    = "zk0p3nNM5;"
+  kafka_user   = "opennms"
+  kafka_passwd = "0p3nNM5;"
+  jks_passwd   = "jks0p3nNM5;"
+  cmak_user    = "opennms"
+  cmak_passwd  = "cmak0p3nNM5;"
+}
+EOF
+
+terraform apply -var-file="custom.tfvars"
 ```
 
-Additionally, if you want to enable SCRAM authentication for Kafka and TLS Encrytion via LetsEncrypt for OpenNMS and Kafka, add `-var "security.enabled=true"` to the list of variables.
+When enabling security, the `cloud-init` scripts will enable SCRAM authentication for Kafka and TLS Encryption via LetsEncrypt for OpenNMS/Grafana via Nginx and Kafka.
 
 All the resources will be prefixed by the content of the `name_prefix` variable for their names.
 
@@ -95,12 +110,4 @@ multipass launch -m 1G -n $minion_id --cloud-init /tmp/$minion_id.yaml
 
 ## Destroy the lab
 
-To destroy all the resources, you should execute the `terraform destroy` command with the same variables you used when executed `terraform apply`, for instance:
-
-```bash
-terraform destroy  \
-  -var "name_prefix=ag-lab1" \
-  -var "username=agalue" \
-  -var "password=1HateWind0ws;" \
-  -var "email=agalue@opennms.org"
-```
+To destroy all the resources, you should execute the `terraform destroy` command with the same variables you used when executed `terraform apply`.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ For testing purposes, this repository provides a `cloud-init` YAML file for Mini
 ```bash
 export name_prefix="ag-lab1"    # Must match name_prefix in Terraform
 export azure_location="eastus"  # Must match location in Terraform
-export security_enabled="false" # Must match security.enabled in Terraform
+export security_enabled="true"  # Must match security.enabled in Terraform
 export kafka_user="opennms"     # Must match security.kafka_user in Terraform
 export kafka_passwd="0p3nNM5;"  # Must match security.kafka_passwd in Terraform
 export minion_heap="512m"       # Must be less than the value specified via -m in multipass

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ terraform init
 
 ```bash
 terraform apply \
+  -var "name_prefix=ag-lab1" \
   -var "username=agalue" \
   -var "password=1HateWind0ws;" \
   -var "email=agalue@opennms.org"
@@ -56,6 +57,7 @@ If you want to create the resource group, you can run the following instead:
 
 ```bash
 terraform apply \
+  -var "name_prefix=ag-lab1" \
   -var "username=agalue" \
   -var "password=1HateWind0ws;" \
   -var "email=agalue@opennms.org" \
@@ -98,15 +100,9 @@ The template assumes you haven't changed the `locals` entry inside `vars.tf`.
 To destroy all the resources, you should execute the `terraform destroy` command with the same variables you used when executed `terraform apply`, for instance:
 
 ```bash
-terraform destroy -var "username=agalue" -var "password=1HateWind0ws;"
-```
-
-Or,
-
-```bash
-terraform destroy \
+terraform destroy  \
+  -var "name_prefix=ag-lab1" \
   -var "username=agalue" \
   -var "password=1HateWind0ws;" \
-  -var "resource_group_create=true" \
-  -var "resource_group_name=OpenNMS"
+  -var "email=agalue@opennms.org"
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ All VMs will have the Net-SNMP agent configured and running.
 For instance, if `location=eastus` and `name_prefix=ag-lab1`, the FQDNs would be:
 
 * `ag-lab1-onms.eastus.cloudapp.opennms.com` (with `security.enabled=false` OpenNMS WebUI=8980 and Grafana=3000; with `security.enabled=true`, both available at 443 via Nginx, using `/opennms` for OpenNMS and `/grafana` for Grafana)
-* `ag-lab1-kafka.eastus.cloudapp.opennms.com` (Client=9094)
+* `ag-lab1-kafka.eastus.cloudapp.opennms.com` (Client=9094, CMAK=9000)
 * `ag-lab1-elastic.eastus.cloudapp.opennms.com` (Kibana=5601)
 
 All instances have SSH access.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ All VMs will have valid FQDN in the `cloudapp.azure.com` domain to facilitate co
 
 All VMs will have the Net-SNMP agent configured and running.
 
-For instance, if `location=eastus` and `username=agalue`, the FQDNs would be:
+For instance, if `location=eastus` and `name_prefix=ag-lab1`, the FQDNs would be:
 
-* `agalue-onms.eastus.cloudapp.opennms.com` (with `security.enabled=false` OpenNMS WebUI=8980 and Grafana=3000; with `security.enabled=true`, both available at 443 (use `/grafana` for Grafana)
-* `agalue-kafka.eastus.cloudapp.opennms.com` (Client=9094)
-* `agalue-elastic.eastus.cloudapp.opennms.com` (Kibana=5601)
+* `ag-lab1-onms.eastus.cloudapp.opennms.com` (with `security.enabled=false` OpenNMS WebUI=8980 and Grafana=3000; with `security.enabled=true`, both available at 443 via Nginx, using `/opennms` for OpenNMS and `/grafana` for Grafana)
+* `ag-lab1-kafka.eastus.cloudapp.opennms.com` (Client=9094)
+* `ag-lab1-elastic.eastus.cloudapp.opennms.com` (Kibana=5601)
 
 All instances have SSH access.
 
@@ -61,13 +61,13 @@ terraform apply \
   -var "username=agalue" \
   -var "password=1HateWind0ws;" \
   -var "email=agalue@opennms.org" \
-  -var "resource_group_create=true" \
-  -var "resource_group_name=OpenNMS"
+  -var "resource_group.create=true" \
+  -var "resource_group.name=OpenNMS"
 ```
 
 Additionally, if you want to enable SCRAM authentication for Kafka and TLS Encrytion via LetsEncrypt for OpenNMS and Kafka, add `-var "security.enabled=true"` to the list of variables.
 
-All the resources will be prefixed by the content of the `username` variable for their names.
+All the resources will be prefixed by the content of the `name_prefix` variable for their names.
 
 The provided credentials will give you SSH access to all the machines, and remember that you can use the generated FQDNs (as all the IP addresses, public and private, are dynamic).
 
@@ -82,13 +82,13 @@ export user="agalue"
 export azure_location="eastus"
 export minion_id="minion01"
 export minion_location="Apex"
-export minion_heap="1g"
+export minion_heap="512m"
 export security_enabled="false"
 export kafka_user="opennms"
 export kafka_passwd="0p3nNM5;"
 
 envsubst < minion-template.yaml > /tmp/$minion_id.yaml
-multipass launch -m 2G -n $minion_id --cloud-init /tmp/$minion_id.yaml
+multipass launch -m 1G -n $minion_id --cloud-init /tmp/$minion_id.yaml
 ```
 
 > Make sure to use use the appropriate `security_enabled` based on how you started the lab, and the credentials are correct (check `vars.tf`).

--- a/README.md
+++ b/README.md
@@ -98,12 +98,12 @@ export azure_location="eastus"  # Must match location in Terraform
 export security_enabled="true"  # Must match security.enabled in Terraform
 export kafka_user="opennms"     # Must match security.kafka_user in Terraform
 export kafka_passwd="0p3nNM5;"  # Must match security.kafka_passwd in Terraform
-export minion_heap="512m"       # Must be less than the value specified via -m in multipass
+export minion_heap="1g"         # Must be less than the value specified via -m in multipass
 export minion_location="Apex"
 export minion_id="ag-minion01"
 
 envsubst < minion-template.yaml > /tmp/$minion_id.yaml
-multipass launch -m 1G -n $minion_id --cloud-init /tmp/$minion_id.yaml
+multipass launch -m 2G -n $minion_id --cloud-init /tmp/$minion_id.yaml
 ```
 
 > Ensure the usage of the appropriate content based on how you started the lab.

--- a/elastic.tf
+++ b/elastic.tf
@@ -3,7 +3,7 @@
 resource "azurerm_network_security_group" "elastic" {
   name                = "${local.elastic_vm_name}-sg"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   security_rule {
@@ -34,7 +34,7 @@ resource "azurerm_network_security_group" "elastic" {
 resource "azurerm_public_ip" "elastic" {
   name                = "${local.elastic_vm_name}-ip"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
   allocation_method   = "Dynamic"
   domain_name_label   = local.elastic_vm_name
@@ -43,7 +43,7 @@ resource "azurerm_public_ip" "elastic" {
 resource "azurerm_network_interface" "elastic" {
   name                = "${local.elastic_vm_name}-nic"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   ip_configuration {
@@ -72,7 +72,7 @@ data "template_file" "elastic" {
 
 resource "azurerm_linux_virtual_machine" "elastic" {
   name                = local.elastic_vm_name
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   location            = var.location
   size                = var.vm_size.elasticsearch
   admin_username      = var.username

--- a/elastic.yaml
+++ b/elastic.yaml
@@ -13,6 +13,7 @@ write_files:
 - owner: root:root
   path: /etc/sysctl.d/99-elastic.conf
   content: |
+    net.ipv4.tcp_retries2=5
     net.ipv4.tcp_keepalive_time=60
     net.ipv4.tcp_keepalive_probes=3
     net.ipv4.tcp_keepalive_intvl=10

--- a/kafka.tf
+++ b/kafka.tf
@@ -3,7 +3,7 @@
 resource "azurerm_network_security_group" "kafka" {
   name                = "${local.kafka_vm_name}-sg"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   security_rule {
@@ -58,7 +58,7 @@ resource "azurerm_network_security_group" "kafka" {
 resource "azurerm_public_ip" "kafka" {
   name                = "${local.kafka_vm_name}-ip"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
   allocation_method   = "Dynamic"
   domain_name_label   = local.kafka_vm_name
@@ -67,7 +67,7 @@ resource "azurerm_public_ip" "kafka" {
 resource "azurerm_network_interface" "kafka" {
   name                = "${local.kafka_vm_name}-nic"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   ip_configuration {
@@ -105,7 +105,7 @@ data "template_file" "kafka" {
 
 resource "azurerm_linux_virtual_machine" "kafka" {
   name                = local.kafka_vm_name
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   location            = var.location
   size                = var.vm_size.kafka
   admin_username      = var.username

--- a/kafka.tf
+++ b/kafka.tf
@@ -93,6 +93,8 @@ data "template_file" "kafka" {
     public_fqdn      = "${local.kafka_vm_name}.${var.location}.cloudapp.azure.com"
     security_enabled = var.security.enabled
     jks_passwd       = var.security.jks_passwd
+    cmak_user        = var.security.cmak_user
+    cmak_passwd      = var.security.cmak_passwd
     zk_heap_size     = var.heap_size.zookeeper
     zk_user          = var.security.zk_user
     zk_passwd        = var.security.zk_passwd

--- a/kafka.tf
+++ b/kafka.tf
@@ -19,7 +19,7 @@ resource "azurerm_network_security_group" "kafka" {
   }
 
   security_rule {
-    name                       = "client"
+    name                       = "client" # For external Minions
     priority                   = 101
     direction                  = "Inbound"
     access                     = "Allow"
@@ -31,13 +31,25 @@ resource "azurerm_network_security_group" "kafka" {
   }
 
   security_rule {
-    name                       = "cmak"
+    name                       = "cmak" # Kafka Manager
     priority                   = 102
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
     destination_port_range     = "9000"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "http" # For LetsEncrypt
+    priority                   = 103
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "80"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
@@ -77,8 +89,15 @@ data "template_file" "kafka" {
   vars = {
     user             = var.username
     location         = var.location
+    email            = var.email
     public_fqdn      = "${local.kafka_vm_name}.${var.location}.cloudapp.azure.com"
+    security_enabled = var.security.enabled
+    jks_passwd       = var.security.jks_passwd
     zk_heap_size     = var.heap_size.zookeeper
+    zk_user          = var.security.zk_user
+    zk_passwd        = var.security.zk_passwd
+    kafka_user       = var.security.kafka_user
+    kafka_passwd     = var.security.kafka_passwd
     kafka_heap_size  = var.heap_size.kafka
     kafka_partitions = 8
   }

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -234,4 +234,4 @@ runcmd:
 - systemctl --now enable snmpd
 - systemctl --now enable docker
 - usermod -aG docker ${user}
-- docker run --name cmak -d -e ZK_HOSTS="$(hostname):2181" -e APPLICATION_SECRET="opennms" -p 9000:9000 hlebalbau/kafka-manager:stable
+- docker run --name cmak -d -e ZK_HOSTS="$(hostname):2181" -e KAFKA_MANAGER_AUTH_ENABLED="true" -e KAFKA_MANAGER_USERNAME="${cmak_user}" -e KAFKA_MANAGER_PASSWORD="${cmak_passwd}" -e APPLICATION_SECRET="${cmak_passwd}" -p 9000:9000 hlebalbau/kafka-manager:stable

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -128,10 +128,19 @@ write_files:
   path: /tmp/enable-authentication.sh
   content: |
     #!/bin/bash
+    function wait_for {
+      echo "Waiting for $1:$2 ."
+      until echo -n >/dev/tcp/$1/$2 2>/dev/null; do
+        printf '.'
+        sleep 5
+      done
+      echo "done"
+    }
     if [ "${security_enabled}" != "true" ]; then
       echo "Security is not enabled"
       exit
     fi
+    wait_for $(hostname) 9092
     /opt/kafka/bin/kafka-configs.sh --bootstrap-server $(hostname):9092 \
       --alter \
       --add-config "SCRAM-SHA-256=[password=${kafka_passwd}],SCRAM-SHA-512=[password=${kafka_passwd}]" \
@@ -153,7 +162,6 @@ write_files:
       user_${zk_user}="${zk_passwd}";
     };
     EOF
-    sudo chown kafka:kafka /opt/kafka/config/zookeeper_jaas.conf
     sudo chmod 0600 /opt/kafka/config/zookeeper_jaas.conf
     cat <<EOF | sudo tee /opt/kafka/config/kafka_jaas.conf
     KafkaServer {
@@ -167,12 +175,16 @@ write_files:
       password="${zk_passwd}";
     };
     EOF
-    sudo chown kafka:kafka /opt/kafka/config/kafka_jaas.conf
     sudo chmod 0600 /opt/kafka/config/kafka_jaas.conf
     OPTS='Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/zookeeper_jaas.conf"'
     sudo sed -i -r -e "/^ExecStart=.*/i $OPTS" /etc/systemd/system/zookeeper.service
     OPTS='Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/kafka_jaas.conf"'
     sudo sed -i -r -e "/^ExecStart=.*/i $OPTS" /etc/systemd/system/kafka.service
+    sudo systemctl daemon-reload
+    sudo systemctl restart zookeeper
+    wait_for 127.0.0.1 2181
+    sudo systemctl restart kafka
+    wait_for $(hostname) 9092
 
 - owner: root:root
   permissions: '0755'
@@ -191,13 +203,12 @@ write_files:
     sudo openssl pkcs12 -export \
       -in /etc/letsencrypt/live/${public_fqdn}/fullchain.pem \
       -inkey /etc/letsencrypt/live/${public_fqdn}/privkey.pem \
-      -out $TEMP_P12 -name kafka -password pass:${jks_passwd}
+      -out $TEMP_P12 -name kafka -password "pass:${jks_passwd}"
     sudo keytool -importkeystore -alias kafka \
-      -deststorepass ${jks_passwd} -destkeypass ${jks_passwd} -destkeystore $TEMP_KEYSTORE \
-      -srckeystore $TEMP_P12 -srcstoretype PKCS12 -srcstorepass ${jks_passwd}
+      -deststorepass "${jks_passwd}" -destkeypass "${jks_passwd}" -destkeystore $TEMP_KEYSTORE \
+      -srckeystore $TEMP_P12 -srcstoretype PKCS12 -srcstorepass "${jks_passwd}"
     sudo cp $TEMP_KEYSTORE $TARGET_KEYSTORE
     sudo chmod 440 $TARGET_KEYSTORE
-    sudo chown kafka:kafka $TARGET_KEYSTORE
     sudo rm -f $TEMP_P12 $TEMP_KEYSTORE
     CONFIG="/opt/kafka/config/server.properties"
     sudo sed -i -r '/listener.security.protocol.map/d' $CONFIG
@@ -207,6 +218,7 @@ write_files:
     ssl.keystore.password=${jks_passwd}
     ssl.key.password=${jks_passwd}
     EOF
+    sudo systemctl restart kafka
 
 packages:
 - net-snmp
@@ -226,12 +238,12 @@ runcmd:
 - mv -f /tmp/*.properties /opt/kafka/config/
 - mkdir -p /data/zookeeper /data/kafka
 - echo 1 > /data/zookeeper/myid
-- /tmp/enable-authentication.sh
-- /tmp/enable-encryption.sh
 - systemctl daemon-reload
 - systemctl --now enable zookeeper
 - systemctl --now enable kafka
 - systemctl --now enable snmpd
 - systemctl --now enable docker
+- /tmp/enable-authentication.sh
+- /tmp/enable-encryption.sh
 - usermod -aG docker ${user}
 - docker run --name cmak -d -e ZK_HOSTS="$(hostname):2181" -e KAFKA_MANAGER_AUTH_ENABLED="true" -e KAFKA_MANAGER_USERNAME="${cmak_user}" -e KAFKA_MANAGER_PASSWORD="${cmak_passwd}" -e APPLICATION_SECRET="${cmak_passwd}" -p 9000:9000 hlebalbau/kafka-manager:stable

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -143,7 +143,6 @@ write_files:
     sudo sed -i -r '/listener.security.protocol.map/d' /opt/kafka/config/server.properties
     cat <<EOF | sudo tee -a /opt/kafka/config/server.properties
     # Enable Security
-    zookeeper.set.acl=true
     listener.security.protocol.map=INSIDE:SASL_PLAINTEXT,OUTSIDE:SASL_PLAINTEXT
     sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
     sasl.enabled.mechanisms=SCRAM-SHA-256,SCRAM-SHA-512
@@ -220,7 +219,7 @@ packages:
 
 runcmd:
 - sysctl --system
-- wget -O /tmp/kafka.tar.gz https://downloads.apache.org/kafka/2.8.0/kafka_2.13-2.8.0.tgz
+- wget -O /tmp/kafka.tar.gz https://downloads.apache.org/kafka/2.8.1/kafka_2.13-2.8.1.tgz
 - cd /opt
 - mkdir kafka
 - tar -xvzf /tmp/kafka.tar.gz -C kafka --strip-components 1

--- a/kafka.yaml
+++ b/kafka.yaml
@@ -123,6 +123,92 @@ write_files:
     # Recommended to avoid disrupting messages workflow
     delete.topic.enable=false
 
+- owner: root:root
+  permissions: '0755'
+  path: /tmp/enable-authentication.sh
+  content: |
+    #!/bin/bash
+    if [ "${security_enabled}" != "true" ]; then
+      echo "Security is not enabled"
+      exit
+    fi
+    /opt/kafka/bin/kafka-configs.sh --bootstrap-server $(hostname):9092 \
+      --alter \
+      --add-config "SCRAM-SHA-256=[password=${kafka_passwd}],SCRAM-SHA-512=[password=${kafka_passwd}]" \
+      --entity-type users \
+      --entity-name ${kafka_user}
+    cat <<EOF | sudo tee -a /opt/kafka/config/zookeeper.properties
+      authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+    EOF
+    sudo sed -i -r '/listener.security.protocol.map/d' /opt/kafka/config/server.properties
+    cat <<EOF | sudo tee -a /opt/kafka/config/server.properties
+    # Enable Security
+    zookeeper.set.acl=true
+    listener.security.protocol.map=INSIDE:SASL_PLAINTEXT,OUTSIDE:SASL_PLAINTEXT
+    sasl.mechanism.inter.broker.protocol=SCRAM-SHA-512
+    sasl.enabled.mechanisms=SCRAM-SHA-256,SCRAM-SHA-512
+    EOF
+    cat <<EOF | sudo tee /opt/kafka/config/zookeeper_jaas.conf
+    Server {
+      org.apache.zookeeper.server.auth.DigestLoginModule required
+      user_${zk_user}="${zk_passwd}";
+    };
+    EOF
+    sudo chown kafka:kafka /opt/kafka/config/zookeeper_jaas.conf
+    sudo chmod 0600 /opt/kafka/config/zookeeper_jaas.conf
+    cat <<EOF | sudo tee /opt/kafka/config/kafka_jaas.conf
+    KafkaServer {
+      org.apache.kafka.common.security.scram.ScramLoginModule required
+      username="${kafka_user}"
+      password="${kafka_passwd}";
+    };
+    Client {
+      org.apache.zookeeper.server.auth.DigestLoginModule required
+      username="${zk_user}"
+      password="${zk_passwd}";
+    };
+    EOF
+    sudo chown kafka:kafka /opt/kafka/config/kafka_jaas.conf
+    sudo chmod 0600 /opt/kafka/config/kafka_jaas.conf
+    OPTS='Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/zookeeper_jaas.conf"'
+    sudo sed -i -r -e "/^ExecStart=.*/i $OPTS" /etc/systemd/system/zookeeper.service
+    OPTS='Environment="KAFKA_OPTS=-Djava.security.auth.login.config=/opt/kafka/config/kafka_jaas.conf"'
+    sudo sed -i -r -e "/^ExecStart=.*/i $OPTS" /etc/systemd/system/kafka.service
+
+- owner: root:root
+  permissions: '0755'
+  path: /tmp/enable-encryption.sh
+  content: |
+    #!/bin/bash
+    if [ "${security_enabled}" != "true" ]; then
+      echo "Security is not enabled"
+      exit
+    fi
+    sudo dnf install -y certbot python3-certbot-nginx
+    sudo certbot certonly --standalone -d ${public_fqdn} --non-interactive --agree-tos -m ${email}
+    TEMP_P12="/tmp/ssl.p12.$(date +%s)"
+    TEMP_KEYSTORE="/tmp/ssl.keystore.$(date +%s)"
+    TARGET_KEYSTORE="/opt/kafka/config/letsencrypt.jks"
+    sudo openssl pkcs12 -export \
+      -in /etc/letsencrypt/live/${public_fqdn}/fullchain.pem \
+      -inkey /etc/letsencrypt/live/${public_fqdn}/privkey.pem \
+      -out $TEMP_P12 -name kafka -password pass:${jks_passwd}
+    sudo keytool -importkeystore -alias kafka \
+      -deststorepass ${jks_passwd} -destkeypass ${jks_passwd} -destkeystore $TEMP_KEYSTORE \
+      -srckeystore $TEMP_P12 -srcstoretype PKCS12 -srcstorepass ${jks_passwd}
+    sudo cp $TEMP_KEYSTORE $TARGET_KEYSTORE
+    sudo chmod 440 $TARGET_KEYSTORE
+    sudo chown kafka:kafka $TARGET_KEYSTORE
+    sudo rm -f $TEMP_P12 $TEMP_KEYSTORE
+    CONFIG="/opt/kafka/config/server.properties"
+    sudo sed -i -r '/listener.security.protocol.map/d' $CONFIG
+    cat <<EOF | sudo tee -a $CONFIG
+    listener.security.protocol.map=INSIDE:SASL_PLAINTEXT,OUTSIDE:SASL_SSL
+    ssl.keystore.location=$TARGET_KEYSTORE
+    ssl.keystore.password=${jks_passwd}
+    ssl.key.password=${jks_passwd}
+    EOF
+
 packages:
 - net-snmp
 - net-snmp-utils
@@ -141,6 +227,8 @@ runcmd:
 - mv -f /tmp/*.properties /opt/kafka/config/
 - mkdir -p /data/zookeeper /data/kafka
 - echo 1 > /data/zookeeper/myid
+- /tmp/enable-authentication.sh
+- /tmp/enable-encryption.sh
 - systemctl daemon-reload
 - systemctl --now enable zookeeper
 - systemctl --now enable kafka

--- a/minion-template.yaml
+++ b/minion-template.yaml
@@ -7,7 +7,7 @@ write_files:
     content: |
       location=${minion_location}
       id=${minion_id}
-      http-url=http://${user}-onms.${azure_location}.cloudapp.azure.com:8980/opennms
+      http-url=http://${name_prefix}-onms.${azure_location}.cloudapp.azure.com:8980/opennms
 
   - owner: root:root
     path: /etc/minion-overlay/featuresBoot.d/kafka.boot
@@ -21,12 +21,12 @@ write_files:
   - owner: root:root
     path: /etc/minion-overlay/org.opennms.core.ipc.sink.kafka.cfg
     content: |
-      bootstrap.servers=${user}-kafka.${azure_location}.cloudapp.azure.com:9094
+      bootstrap.servers=${name_prefix}-kafka.${azure_location}.cloudapp.azure.com:9094
 
   - owner: root:root
     path: /etc/minion-overlay/org.opennms.core.ipc.rpc.kafka.cfg
     content: |
-      bootstrap.servers=${user}-kafka.${azure_location}.cloudapp.azure.com:9094
+      bootstrap.servers=${name_prefix}-kafka.${azure_location}.cloudapp.azure.com:9094
       single-topic=true
 
   - owner: root:root
@@ -34,7 +34,7 @@ write_files:
     path: /tmp/enable-security.sh
     content: |
       #!/bin/bash
-      if [ "$security_enabled" != "true" ]; then
+      if [ "${security_enabled}" != "true" ]; then
         echo "Security is not enabled"
         exit
       fi
@@ -44,14 +44,12 @@ write_files:
       sasl.mechanism=SCRAM-SHA-512
       sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$kafka_user" password="$kafka_passwd";
       EOF
-      done
       cat <<EOF | sudo tee -a /etc/minion-overlay/org.opennms.core.ipc.rpc.kafka.cfg
       # Security
       security.protocol=SASL_SSL
       sasl.mechanism=SCRAM-SHA-512
       sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$kafka_user" password="$kafka_passwd";
       EOF
-      done
 
 apt:
   preserve_sources_list: true

--- a/minion-template.yaml
+++ b/minion-template.yaml
@@ -64,10 +64,10 @@ bootcmd:
   - curl -s https://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
 
 runcmd:
-  - /tmp/enable-security.sh
   - rsync -avr /etc/minion-overlay/ /etc/minion/
   - sed -i -r 's/# export JAVA_MIN_MEM=.*/export JAVA_MIN_MEM="$minion_heap"/' /etc/default/minion
   - sed -i -r 's/# export JAVA_MAX_MEM=.*/export JAVA_MAX_MEM="$minion_heap"/' /etc/default/minion
   - /usr/share/minion/bin/scvcli set opennms.http admin admin
   - /usr/share/minion/bin/scvcli set opennms.broker admin admin
+  - /tmp/enable-security.sh
   - systemctl --now enable minion

--- a/minion-template.yaml
+++ b/minion-template.yaml
@@ -50,6 +50,10 @@ write_files:
       sasl.mechanism=SCRAM-SHA-512
       sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$kafka_user" password="$kafka_passwd";
       EOF
+      sudo sed -i -r "/http-url/d" /etc/minion/org.opennms.minion.controller.cfg
+      cat <<EOF | sudo tee -a etc/minion/org.opennms.minion.controller.cfg
+      http-url=https://${name_prefix}-onms.${azure_location}.cloudapp.azure.com/opennms
+      EOF
 
 apt:
   preserve_sources_list: true

--- a/minion-template.yaml
+++ b/minion-template.yaml
@@ -29,6 +29,30 @@ write_files:
       bootstrap.servers=${user}-kafka.eastus.cloudapp.azure.com:9094
       single-topic=true
 
+  - owner: root:root
+    permissions: '0755'
+    path: /tmp/enable-security.sh
+    content: |
+      #!/bin/bash
+      if [ "$security_enabled" != "true" ]; then
+        echo "Security is not enabled"
+        exit
+      fi
+      cat <<EOF | sudo tee -a /etc/minion-overlay/org.opennms.core.ipc.sink.kafka.cfg
+      # Security
+      security.protocol=SASL_SSL
+      sasl.mechanism=SCRAM-SHA-512
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$kafka_user" password="$kafka_passwd";
+      EOF
+      done
+      cat <<EOF | sudo tee -a /etc/minion-overlay/org.opennms.core.ipc.rpc.kafka.cfg
+      # Security
+      security.protocol=SASL_SSL
+      sasl.mechanism=SCRAM-SHA-512
+      sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="$kafka_user" password="$kafka_passwd";
+      EOF
+      done
+
 apt:
   preserve_sources_list: true
   sources:
@@ -42,9 +66,10 @@ bootcmd:
   - curl -s https://debian.opennms.org/OPENNMS-GPG-KEY | apt-key add -
 
 runcmd:
+  - /tmp/enable-security.sh
   - rsync -avr /etc/minion-overlay/ /etc/minion/
-  - sed -i -r 's/# export JAVA_MIN_MEM=.*/export JAVA_MIN_MEM="${minion_heap}"/' /etc/default/minion
-  - sed -i -r 's/# export JAVA_MAX_MEM=.*/export JAVA_MAX_MEM="${minion_heap}"/' /etc/default/minion
+  - sed -i -r 's/# export JAVA_MIN_MEM=.*/export JAVA_MIN_MEM="$minion_heap"/' /etc/default/minion
+  - sed -i -r 's/# export JAVA_MAX_MEM=.*/export JAVA_MAX_MEM="$minion_heap"/' /etc/default/minion
   - /usr/share/minion/bin/scvcli set opennms.http admin admin
   - /usr/share/minion/bin/scvcli set opennms.broker admin admin
   - systemctl --now enable minion

--- a/opennms.tf
+++ b/opennms.tf
@@ -3,7 +3,7 @@
 resource "azurerm_network_security_group" "opennms" {
   name                = "${local.onms_vm_name}-sg"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   security_rule {
@@ -58,7 +58,7 @@ resource "azurerm_network_security_group" "opennms" {
 resource "azurerm_public_ip" "opennms" {
   name                = "${local.onms_vm_name}-ip"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
   allocation_method   = "Dynamic"
   domain_name_label   = local.onms_vm_name
@@ -67,7 +67,7 @@ resource "azurerm_public_ip" "opennms" {
 resource "azurerm_network_interface" "opennms" {
   name                = "${local.onms_vm_name}-nic"
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   tags                = local.custom_tags
 
   ip_configuration {
@@ -106,7 +106,7 @@ data "template_file" "opennms" {
 
 resource "azurerm_linux_virtual_machine" "opennms" {
   name                = local.onms_vm_name
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   location            = var.location
   size                = var.vm_size.opennms
   admin_username      = var.username

--- a/opennms.yaml
+++ b/opennms.yaml
@@ -75,6 +75,69 @@ write_files:
     settings.index.number_of_replicas=0
 
 - owner: root:root
+  path: /etc/nginx/default.d/opennms.conf
+  content: |
+    server_name ${public_fqdn};
+    # maintain the .well-known directory alias for LetsEncrypt renewals
+    location /.well-known {
+      alias /var/www/${public_fqdn}/.well-known;
+    }
+    location /hawtio/ {
+      proxy_pass http://localhost:8980/hawtio/;
+    }
+    location /grafana/ {
+      proxy_pass http://localhost:3000/;
+    }
+    location /opennms/ {
+      proxy_set_header    Host $host;
+      proxy_set_header    X-Real-IP $remote_addr;
+      proxy_set_header    X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header    X-Forwarded-Proto $scheme;
+      proxy_set_header    Upgrade $http_upgrade;
+      proxy_set_header    Connection "Upgrade";
+      proxy_pass          http://localhost:8980/opennms/;
+      proxy_redirect      default;
+      proxy_read_timeout  90;
+    }
+
+- owner: root:root
+  permissions: '0755'
+  path: /tmp/enable-security.sh
+  content: |
+    #!/bin/bash
+    if [ "${security_enabled}" != "true" ]; then
+      echo "Security is not enabled"
+      exit
+    fi
+    dnf install -y nginx certbot python3-certbot-nginx
+    mkdir -p /var/www/${public_fqdn}/.well-known
+    chown nginx:nginx /var/www
+    setsebool -P httpd_can_network_connect 1
+    systemctl --now enable nginx
+    sleep 5
+    certbot --nginx -d ${public_fqdn} --non-interactive --agree-tos -m ${email}
+    sed -i -r "s|^;domain =.*|domain = ${public_fqdn}|" /etc/grafana/grafana.ini
+    sed -i -r "s|^;root_url =.*|root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/|" /etc/grafana/grafana.ini
+    cat <<EOF > /opt/opennms/etc/opennms.properties.d/webui.properties
+    org.opennms.netmgt.jetty.host = 127.0.0.1
+    opennms.web.base-url = https://%x%c/
+    EOF
+    for module in sink rpc; do
+      cat <<EOF >> /etc/opennms/opennms.properties.d/kafka.properties
+    # Security for $module
+    org.opennms.core.ipc.$module.kafka.security.protocol=SASL_PLAINTEXT
+    org.opennms.core.ipc.$module.kafka.sasl.mechanism=SCRAM-SHA-512
+    org.opennms.core.ipc.$module.kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${kafka_user}" password="${kafka_passwd}";
+    EOF
+    done
+    cat <<EOF >> /etc/opennms/org.opennms.features.kafka.producer.client.cfg
+    # Security
+    security.protocol=SASL_PLAINTEXT
+    sasl.mechanism=SCRAM-SHA-512
+    sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${kafka_user}" password="${kafka_passwd}";
+    EOF
+
+- owner: root:root
   permissions: '0400'
   path: /etc/snmp/snmpd.conf
   content: |
@@ -108,12 +171,11 @@ runcmd:
 - sed -r -i "/^(local|host)/s/(peer|ident)/trust/g" /var/lib/pgsql/data/pg_hba.conf
 - systemctl --now enable postgresql
 
-# Configure and start OpenNMS
+# Configure and start OpenNMS and Grafana
 - echo 'JAVA_HEAP_SIZE=${heap_size}' > /opt/opennms/etc/opennms.conf
 - sed -r -i 's/enabled="false"/enabled="true"/' /opt/opennms/etc/telemetryd-configuration.xml
 - /opt/opennms/bin/runjava -s
 - /opt/opennms/bin/install -dis
+- /tmp/enable-security.sh
 - systemctl --now enable opennms
-
-# Configure and start Grafana
 - systemctl --now enable grafana-server

--- a/opennms.yaml
+++ b/opennms.yaml
@@ -123,14 +123,14 @@ write_files:
     opennms.web.base-url = https://%x%c/
     EOF
     for module in sink rpc; do
-      cat <<EOF >> /etc/opennms/opennms.properties.d/kafka.properties
+      cat <<EOF >> /opt/opennms/etc/opennms.properties.d/kafka.properties
     # Security for $module
     org.opennms.core.ipc.$module.kafka.security.protocol=SASL_PLAINTEXT
     org.opennms.core.ipc.$module.kafka.sasl.mechanism=SCRAM-SHA-512
     org.opennms.core.ipc.$module.kafka.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="${kafka_user}" password="${kafka_passwd}";
     EOF
     done
-    cat <<EOF >> /etc/opennms/org.opennms.features.kafka.producer.client.cfg
+    cat <<EOF >> /opt/opennms/etc/org.opennms.features.kafka.producer.client.cfg
     # Security
     security.protocol=SASL_PLAINTEXT
     sasl.mechanism=SCRAM-SHA-512

--- a/vars.tf
+++ b/vars.tf
@@ -130,6 +130,8 @@ variable "security" {
     kafka_user   = string
     kafka_passwd = string
     jks_passwd   = string
+    cmak_user    = string
+    cmak_passwd  = string
   })
   default = {
     enabled      = false
@@ -138,6 +140,8 @@ variable "security" {
     kafka_user   = "opennms"
     kafka_passwd = "0p3nNM5;"
     jks_passwd   = "jks0p3nNM5;"
+    cmak_user    = "opennms"
+    cmak_passwd  = "cmak0p3nNM5;"
   }
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -10,6 +10,11 @@ variable "password" {
   type        = string
 }
 
+variable "email" {
+  description = "Email address to use with LetsEncrypt for TLS; used only when security.enabled=true"
+  type        = string
+}
+
 variable "location" {
   description = "Azure Location/Region"
   type        = string
@@ -87,6 +92,26 @@ variable "heap_size" {
     zookeeper     = "2048"
     kafka         = "2048"
     elasticsearch = "4096"
+  }
+}
+
+variable "security" {
+  description = "Credentials to access servers"
+  type = object({
+    enabled      = bool
+    zk_user      = string
+    zk_passwd    = string
+    kafka_user   = string
+    kafka_passwd = string
+    jks_passwd   = string
+  })
+  default = {
+    enabled      = false
+    zk_user      = "zkonms"
+    zk_passwd    = "zk0p3nNM5;"
+    kafka_user   = "opennms"
+    kafka_passwd = "0p3nNM5;"
+    jks_passwd   = "jks0p3nNM5;"
   }
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -3,7 +3,7 @@
 variable "name_prefix" {
   description = "A prefix to add to all Azure resources, to make them unique."
   type        = string
-  default     = "agalue"
+  default     = "ag-lab1"
 }
 
 variable "username" {
@@ -28,16 +28,16 @@ variable "location" {
   default     = "eastus"
 }
 
-variable "resource_group_create" {
-  description = "Set to true to create the resource group (false to reuse an existing one)"
-  type        = bool
-  default     = false
-}
-
-variable "resource_group_name" {
-  description = "Name of the resource group"
-  type        = string
-  default     = "support-testing"
+variable "resource_group" {
+  description = "Azure resource group"
+  type        = object({
+    create = bool
+    name   = string
+  })
+  default = {
+    create = false
+    name = "support-testing"
+  }
 }
 
 # Must be consistent with the chosen Location/Region
@@ -57,7 +57,6 @@ variable "os_image" {
   }
 }
 
-# Used only when resource_group_create=true
 variable "address_space" {
   description = "Virtual Network Address Space"
   type        = string
@@ -80,9 +79,9 @@ variable "vm_size" {
     elasticsearch = string
   })
   default = {
-    opennms       = "Standard_DS4_v2"
-    kafka         = "Standard_DS4_v2"
-    elasticsearch = "Standard_DS4_v2"
+    opennms       = "Standard_DS3_v2"
+    kafka         = "Standard_DS3_v2"
+    elasticsearch = "Standard_DS3_v2"
   }
 }
 
@@ -148,6 +147,7 @@ locals {
     Department   = "Support"
     Owner        = var.username
   }
+  vnet_name = "${var.name_prefix}-vnet"
   onms_vm_name = "${var.name_prefix}-onms"
   kafka_vm_name = "${var.name_prefix}-kafka"
   elastic_vm_name = "${var.name_prefix}-elastic"

--- a/vars.tf
+++ b/vars.tf
@@ -79,9 +79,9 @@ variable "vm_size" {
     elasticsearch = string
   })
   default = {
-    opennms       = "Standard_DS3_v2"
-    kafka         = "Standard_DS3_v2"
-    elasticsearch = "Standard_DS3_v2"
+    opennms       = "Standard_D2s_v3"
+    kafka         = "Standard_D2s_v3"
+    elasticsearch = "Standard_D2s_v3"
   }
 }
 

--- a/vars.tf
+++ b/vars.tf
@@ -1,7 +1,13 @@
 # Author: Alejandro Galue <agalue@opennms.org>
 
+variable "name_prefix" {
+  description = "A prefix to add to all Azure resources, to make them unique."
+  type        = string
+  default     = "agalue"
+}
+
 variable "username" {
-  description = "Username to access the VMs and uniquely identify all Azure resources"
+  description = "The user to access VMs and name prefix for Azure resources."
   type        = string
 }
 
@@ -46,7 +52,7 @@ variable "os_image" {
   default = {
     publisher = "OpenLogic"
     offer     = "CentOS"
-    sku       = "8_3"
+    sku       = "8_4"
     version   = "latest"
   }
 }
@@ -101,8 +107,8 @@ variable "onms_repo" {
   type        = string
   default     = "stable"
   validation {
-    condition = can(regex("^(stable|oldstable|obsolete|bleeding)$", var.onms_repo))
-    error_message = "The onms_repo can only be stable, oldstable, obsolete, or bleeding."
+    condition = can(regex("^(stable|oldstable|obsolete)$", var.onms_repo))
+    error_message = "The onms_repo can only be stable, oldstable, or obsolete."
   }
 }
 
@@ -142,7 +148,7 @@ locals {
     Department   = "Support"
     Owner        = var.username
   }
-  onms_vm_name = "${var.username}-onms"
-  kafka_vm_name = "${var.username}-kafka"
-  elastic_vm_name = "${var.username}-elastic"
+  onms_vm_name = "${var.name_prefix}-onms"
+  kafka_vm_name = "${var.name_prefix}-kafka"
+  elastic_vm_name = "${var.name_prefix}-elastic"
 }

--- a/vnet.tf
+++ b/vnet.tf
@@ -1,23 +1,23 @@
 # Author: Alejandro Galue <agalue@opennms.org>
 
 resource "azurerm_resource_group" "main" {
-  count    = var.resource_group_create ? 1 : 0
-  name     = var.resource_group_name
+  count    = var.resource_group.create ? 1 : 0
+  name     = var.resource_group.name
   location = var.location
   tags     = local.custom_tags
 }
 
 resource "azurerm_virtual_network" "main" {
-  name                =  "${var.username}-onms-vnet"
+  name                = local.vnet_name
   location            = var.location
-  resource_group_name = var.resource_group_name
+  resource_group_name = var.resource_group.name
   address_space       = [var.address_space]
   tags                = local.custom_tags
 }
 
 resource "azurerm_subnet" "main" {
   name                 = "main"
-  resource_group_name  = var.resource_group_name
+  resource_group_name  = var.resource_group.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = [var.subnet]
 }


### PR DESCRIPTION
The original lab creates resources exposed to the Internet without security. That can lead to a security breach if the lab will be running for long periods.

For this reason, we must secure the resources exposed to the Internet with authentication and encryption. To simplify the deployment, I used LetsEncrypt to manage the certificates. In the future, we could add support for self-signed or a private certificate chain to test other use cases.